### PR TITLE
feat: Complete core scene flow (closes #2)

### DIFF
--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -55,3 +55,18 @@ text = "Kills: 0"
 [node name="TimerLabel" type="Label" parent="HUD/HUDPanel"]
 layout_mode = 2
 text = "0:00"
+
+[node name="EndRunButton" type="Button" parent="HUD"]
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -156.0
+offset_top = -56.0
+offset_right = -16.0
+offset_bottom = -16.0
+grow_horizontal = 0
+grow_vertical = 0
+theme_override_font_sizes/font_size = 16
+text = "End Run"

--- a/scripts/ui/Game.gd
+++ b/scripts/ui/Game.gd
@@ -14,24 +14,40 @@
 extends Node2D
 ## Game scene controller. Manages the active run.
 
-var run_time: float = 0.0
-var wave_number: int = 0
-var kills: int = 0
-var salvage: int = 0
-
 func _ready() -> void:
-	run_time = 0.0
-	wave_number = 0
-	kills = 0
-	salvage = 0
+	RunState.reset()
+	EventBus.run_started.emit()
+	$HUD/EndRunButton.pressed.connect(_on_end_run_pressed)
+	_update_hud()
 
 func _process(delta: float) -> void:
-	run_time += delta
+	RunState.run_time += delta
 	_update_hud()
+
+func _on_end_run_pressed() -> void:
+	_end_run()
+
+func _end_run() -> void:
+	EventBus.run_ended.emit(
+		RunState.wave_number,
+		RunState.kills,
+		RunState.salvage,
+		RunState.run_time
+	)
+	GameState.record_run(
+		RunState.wave_number,
+		RunState.kills,
+		RunState.salvage,
+		RunState.run_time
+	)
+	get_tree().change_scene_to_file("res://scenes/RunSummary.tscn")
 
 func _update_hud() -> void:
 	var hud_panel: HBoxContainer = $HUD/HUDPanel
-	hud_panel.get_node("TimerLabel").text = _format_time(run_time)
+	hud_panel.get_node("HPLabel").text = "HP: %d" % RunState.tower_hp
+	hud_panel.get_node("WaveLabel").text = "Wave: %d" % RunState.wave_number
+	hud_panel.get_node("KillsLabel").text = "Kills: %d" % RunState.kills
+	hud_panel.get_node("TimerLabel").text = _format_time(RunState.run_time)
 
 func _format_time(seconds: float) -> String:
 	var mins: int = int(seconds) / 60

--- a/scripts/ui/RunSummary.gd
+++ b/scripts/ui/RunSummary.gd
@@ -17,9 +17,22 @@ extends Control
 func _ready() -> void:
 	$CenterContainer/VBoxContainer/RestartButton.pressed.connect(_on_restart_pressed)
 	$CenterContainer/VBoxContainer/MenuButton.pressed.connect(_on_menu_pressed)
+	_populate_stats()
+
+func _populate_stats() -> void:
+	var vbox: VBoxContainer = $CenterContainer/VBoxContainer
+	vbox.get_node("WaveLabel").text = "Wave Reached: %d" % RunState.wave_number
+	vbox.get_node("KillsLabel").text = "Enemies Killed: %d" % RunState.kills
+	vbox.get_node("TimeLabel").text = "Time Survived: %s" % _format_time(RunState.run_time)
+	vbox.get_node("SalvageLabel").text = "Salvage Earned: %d" % RunState.salvage
 
 func _on_restart_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/Game.tscn")
 
 func _on_menu_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+func _format_time(seconds: float) -> String:
+	var mins: int = int(seconds) / 60
+	var secs: int = int(seconds) % 60
+	return "%d:%02d" % [mins, secs]


### PR DESCRIPTION
## Summary

Completes Issue #2 — Add Core Scene Flow by filling the missing link between the Game scene and RunSummary scene.

### Problem
The initial scaffold had all three scenes (MainMenu, Game, RunSummary) but the **Game scene had no way to transition to RunSummary**. Players would be stuck in the Game scene indefinitely with no game-over trigger or exit button. Additionally, the Game scene used local variables instead of the `RunState` singleton, and RunSummary displayed static placeholder text instead of actual run data.

### Changes
| File | Change |
|------|--------|
| `scenes/Game.tscn` | Added "End Run" button anchored to bottom-right of HUD |
| `scripts/ui/Game.gd` | Replaced local vars with `RunState` singleton; added `_end_run()` that emits `EventBus.run_ended`, records stats via `GameState.record_run`, and transitions to RunSummary |
| `scripts/ui/RunSummary.gd` | Added `_populate_stats()` to read run data from `RunState` and populate all labels dynamically |
| `scripts/ui/MainMenu.gd` | No functional change (Start Run already works correctly) |

### Acceptance Criteria Verification
- [x] **Player can start a run from the main menu** — StartButton transitions to Game.tscn
- [x] **Player can reach a placeholder run summary** — End Run button transitions to RunSummary.tscn
- [x] **Player can return to main menu** — Main Menu button transitions back to MainMenu.tscn

### Scene Flow
```
MainMenu -> [Start Run] -> Game -> [End Run] -> RunSummary -> [Main Menu] -> MainMenu
                                              -> [Restart]  -> Game
```

Closes #2
