### PR TITLE
feat: implement Tower node (closes #5)

### DIFF
--- a/scenes/Tower.tscn
+++ b/scenes/Tower.tscn
@@ -1,3 +1,44 @@
-extends Node2D
-## Tower scene root. Composes Tower.gd with visual components.
-## Will be implemented in Sprint 1 (Issue #5).
+[gd_scene load_steps=2 format=3 uid="uid://bqtower001"]
+
+[ext_resource type="Script" path="res://scripts/combat/Tower.gd" id="1_tower"]
+
+[node name="Tower" type="Node2D"]
+script = ExtResource("1_tower")
+
+[node name="TowerBody" type="ColorRect" parent="."]
+offset_left = -20.0
+offset_top = -20.0
+offset_right = 20.0
+offset_bottom = 20.0
+color = Color(0.2, 0.6, 1, 1)
+
+[node name="BarrelPivot" type="Node2D" parent="."]
+position = Vector2(0, 0)
+
+[node name="Barrel" type="ColorRect" parent="BarrelPivot"]
+offset_left = -3.0
+offset_top = -30.0
+offset_right = 3.0
+offset_bottom = 0.0
+color = Color(0.4, 0.8, 1, 1)
+
+[node name="RangeArea" type="Area2D" parent="."]
+collision_mask = 2
+
+[node name="RangeCollision" type="CollisionShape2D" parent="RangeArea"]
+shape = SubResource("CircleShape2D_range")
+
+[node name="Hitbox" type="Area2D" parent="."]
+collision_layer = 1
+collision_mask = 4
+
+[node name="HitboxCollision" type="CollisionShape2D" parent="Hitbox"]
+shape = SubResource("CircleShape2D_hitbox")
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_range"]
+resource_name = "CircleShape2D_range"
+radius = 300.0
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_hitbox"]
+resource_name = "CircleShape2D_hitbox"
+radius = 22.0

--- a/scripts/combat/Tower.gd
+++ b/scripts/combat/Tower.gd
@@ -13,4 +13,74 @@
 
 extends Node2D
 ## Tower entity. Handles HP, rotation, targeting, and weapon firing.
-## Will be implemented in Sprint 1 (Issue #5).
+
+signal died
+
+@export var max_hp: int = Constants.DEFAULT_TOWER_HP
+@export var tower_range: float = Constants.DEFAULT_TOWER_RANGE
+@export var fire_rate: float = Constants.DEFAULT_FIRE_RATE
+@export var damage: int = Constants.DEFAULT_DAMAGE
+@export var projectile_speed: float = Constants.DEFAULT_PROJECTILE_SPEED
+
+var hp: int = 0
+var _fire_cooldown: float = 0.0
+var _target: Node2D = null
+var _enemies_in_range: Array[Node2D] = []
+
+@onready var _barrel: Node2D = $BarrelPivot
+@onready var _range_area: Area2D = $RangeArea
+@onready var _body: ColorRect = $TowerBody
+
+func _ready() -> void:
+	hp = max_hp
+	if _range_area:
+		_range_area.body_entered.connect(_on_body_entered)
+		_range_area.body_exited.connect(_on_body_exited)
+
+func _process(delta: float) -> void:
+	_update_target()
+	_rotate_toward_target()
+	_fire_cooldown -= delta
+
+func take_damage(amount: int, source: String = "") -> void:
+	hp = max(0, hp - amount)
+	EventBus.tower_damaged.emit(amount, source)
+	RunState.tower_hp = hp
+	if hp <= 0:
+		died.emit()
+		queue_free()
+
+func heal(amount: int) -> void:
+	hp = min(max_hp, hp + amount)
+	RunState.tower_hp = hp
+	EventBus.tower_healed.emit(amount)
+
+func get_target() -> Node2D:
+	return _target
+
+func _update_target() -> void:
+	_enemies_in_range = _enemies_in_range.filter(func(e): return is_instance_valid(e))
+	if _enemies_in_range.is_empty():
+		_target = null
+		return
+	var best: Node2D = null
+	var best_dist: float = INF
+	for enemy in _enemies_in_range:
+		var dist: float = global_position.distance_to(enemy.global_position)
+		if dist < best_dist:
+			best_dist = dist
+			best = enemy
+	_target = best
+
+func _rotate_toward_target() -> void:
+	if _target == null or _barrel == null:
+		return
+	var angle: float = global_position.direction_to(_target.global_position).angle()
+	_barrel.rotation = angle
+
+func _on_body_entered(body: Node2D) -> void:
+	if body.is_in_group("enemies"):
+		_enemies_in_range.append(body)
+
+func _on_body_exited(body: Node2D) -> void:
+	_enemies_in_range.erase(body)


### PR DESCRIPTION
## Summary

Implements Issue #5 - Tower Node with HP, range, targeting, and rotation.

### Changes
| File | Change |
|------|--------|
| scripts/combat/Tower.gd | Full implementation: HP, take_damage/heal, nearest-enemy targeting, barrel rotation |
| scenes/Tower.tscn | Body rect, barrel pivot, Area2D range detection |

### Acceptance Criteria
- [x] Tower appears in center of game scene (ready for wiring in Game.tscn)
- [x] Tower has HP (syncs to RunState)
- [x] Tower can identify nearby enemies (Area2D range detection)
- [x] Tower can rotate or visually aim at target (barrel pivot)

Closes #5