### PR TITLE
feat: implement Enemy node (closes #6)

### DIFF
--- a/scenes/Enemy.tscn
+++ b/scenes/Enemy.tscn
@@ -1,3 +1,24 @@
-extends Node2D
-## Enemy scene root. Composes Enemy.gd with visual components.
-## Will be implemented in Sprint 1 (Issue #6).
+[gd_scene load_steps=2 format=3 uid="uid://bqenemy001"]
+
+[ext_resource type="Script" path="res://scripts/combat/Enemy.gd" id="1_enemy"]
+
+[node name="Enemy" type="Node2D"]
+script = ExtResource("1_enemy")
+
+[node name="EnemyBody" type="ColorRect" parent="."]
+offset_left = -8.0
+offset_top = -8.0
+offset_right = 8.0
+offset_bottom = 8.0
+color = Color(0.33, 1, 0.33, 1)
+
+[node name="Hitbox" type="Area2D" parent="."]
+collision_layer = 2
+collision_mask = 1
+
+[node name="HitboxCollision" type="CollisionShape2D" parent="Hitbox"]
+shape = SubResource("CircleShape2D_enemy")
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_enemy"]
+resource_name = "CircleShape2D_enemy"
+radius = 10.0

--- a/scripts/combat/Enemy.gd
+++ b/scripts/combat/Enemy.gd
@@ -13,4 +13,77 @@
 
 extends Node2D
 ## Enemy entity. Handles movement toward tower, HP, damage, and death.
-## Will be implemented in Sprint 1 (Issue #6).
+
+signal died(enemy: Node2D)
+
+var enemy_id: String = ""
+var hp: int = 15
+var max_hp: int = 15
+var speed: float = 120.0
+var damage: int = 5
+var salvage_reward: int = 2
+var enemy_color: Color = Color.GREEN
+var enemy_size: float = 8.0
+var _tower_position: Vector2 = Vector2.ZERO
+var _attack_cooldown: float = 0.0
+var _attack_interval: float = 1.0
+
+@onready var _body: ColorRect = $EnemyBody
+@onready var _hitbox: Area2D = $Hitbox
+
+func _ready() -> void:
+	add_to_group("enemies")
+	_update_visual()
+
+func setup(data: Dictionary, tower_pos: Vector2) -> void:
+	enemy_id = data.get("id", "unknown")
+	hp = data.get("hp", 15)
+	max_hp = hp
+	speed = data.get("speed", 120.0)
+	damage = data.get("damage", 5)
+	salvage_reward = data.get("salvage_reward", 2)
+	enemy_color = Color.from_string(data.get("color", "#55ff55"), Color.GREEN)
+	enemy_size = data.get("size", 8.0)
+	_tower_position = tower_pos
+	_update_visual()
+
+func _process(delta: float) -> void:
+	if _tower_position == Vector2.ZERO:
+		return
+	var direction: Vector2 = global_position.direction_to(_tower_position)
+	var distance: float = global_position.distance_to(_tower_position)
+	if distance > 24.0:
+		global_position += direction * speed * delta
+	else:
+		_attack_cooldown -= delta
+		if _attack_cooldown <= 0.0:
+			_attack_tower()
+			_attack_cooldown = _attack_interval
+
+func take_damage(amount: int) -> void:
+	hp -= amount
+	if hp <= 0:
+		_die()
+
+func _attack_tower() -> void:
+	var towers: Array[Node] = get_tree().get_nodes_in_group("tower")
+	if towers.size() > 0:
+		var tower: Node2D = towers[0]
+		if tower.has_method("take_damage"):
+			tower.take_damage(damage, enemy_id)
+
+func _die() -> void:
+	EventBus.enemy_killed.emit(enemy_id, salvage_reward)
+	RunState.kills += 1
+	RunState.salvage += salvage_reward
+	died.emit(self)
+	queue_free()
+
+func _update_visual() -> void:
+	if _body:
+		_body.color = enemy_color
+		var half: float = enemy_size
+		_body.offset_left = -half
+		_body.offset_top = -half
+		_body.offset_right = half
+		_body.offset_bottom = half


### PR DESCRIPTION
## Summary

Implements Issue #6 - Enemy Node with movement, HP, damage, and death.

### Changes
| File | Change |
|------|--------|
| scripts/combat/Enemy.gd | Full implementation: setup from JSON, move toward tower, attack interval, take_damage, death with rewards |
| scenes/Enemy.tscn | ColorRect body, Area2D hitbox |

### Acceptance Criteria
- [x] Enemy can spawn (setup() from JSON data)
- [x] Enemy moves toward tower (direction-based movement)
- [x] Enemy damages tower (attack on proximity with cooldown)
- [x] Enemy can be killed (take_damage + _die with EventBus.enemy_killed)

Closes #6