### PR TITLE
feat: complete basic HUD with salvage display (closes #8)

### DIFF
--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -52,6 +52,10 @@ text = "Wave: 0"
 layout_mode = 2
 text = "Kills: 0"
 
+[node name="SalvageLabel" type="Label" parent="HUD/HUDPanel"]
+layout_mode = 2
+text = "Salvage: 0"
+
 [node name="TimerLabel" type="Label" parent="HUD/HUDPanel"]
 layout_mode = 2
 text = "0:00"

--- a/scripts/ui/Game.gd
+++ b/scripts/ui/Game.gd
@@ -47,6 +47,7 @@ func _update_hud() -> void:
 	hud_panel.get_node("HPLabel").text = "HP: %d" % RunState.tower_hp
 	hud_panel.get_node("WaveLabel").text = "Wave: %d" % RunState.wave_number
 	hud_panel.get_node("KillsLabel").text = "Kills: %d" % RunState.kills
+	hud_panel.get_node("SalvageLabel").text = "Salvage: %d" % RunState.salvage
 	hud_panel.get_node("TimerLabel").text = _format_time(RunState.run_time)
 
 func _format_time(seconds: float) -> String:


### PR DESCRIPTION
## Summary

Implements Issue #8 - Basic HUD with all run stats.

### Changes
| File | Change |
|------|--------|
| scenes/Game.tscn | Added SalvageLabel to HUD panel |
| scripts/ui/Game.gd | Updated _update_hud() to display salvage |

### Acceptance Criteria
- [x] HUD updates in real time (HP, Wave, Kills, Salvage, Timer via RunState)
- [x] HUD remains readable during combat (top-left, HBoxContainer)
- [x] HUD does not block central gameplay (anchored to top-left corner)

Closes #8