### PR TITLE
feat: implement death and restart with full combat loop (closes #9)

### DIFF
--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -12,23 +12,6 @@ offset_right = 640.0
 offset_bottom = 360.0
 color = Color(0.03, 0.03, 0.06, 1)
 
-[node name="Tower" type="Node2D" parent="."]
-position = Vector2(0, 0)
-
-[node name="TowerBody" type="ColorRect" parent="Tower"]
-offset_left = -20.0
-offset_top = -20.0
-offset_right = 20.0
-offset_bottom = 20.0
-color = Color(0.2, 0.6, 1, 1)
-
-[node name="TowerBarrel" type="ColorRect" parent="Tower"]
-offset_left = -3.0
-offset_top = -30.0
-offset_right = 3.0
-offset_bottom = 0.0
-color = Color(0.4, 0.8, 1, 1)
-
 [node name="HUD" type="CanvasLayer" parent="."]
 layer = 10
 
@@ -36,7 +19,7 @@ layer = 10
 anchors_preset = 0
 offset_left = 16.0
 offset_top = 16.0
-offset_right = 400.0
+offset_right = 480.0
 offset_bottom = 48.0
 theme_override_constants/separation = 24
 

--- a/scripts/combat/Tower.gd
+++ b/scripts/combat/Tower.gd
@@ -32,6 +32,7 @@ var _enemies_in_range: Array[Node2D] = []
 @onready var _body: ColorRect = $TowerBody
 
 func _ready() -> void:
+	add_to_group("tower")
 	hp = max_hp
 	if _range_area:
 		_range_area.body_entered.connect(_on_body_entered)

--- a/scripts/ui/Game.gd
+++ b/scripts/ui/Game.gd
@@ -12,22 +12,61 @@
 # - Update docs when behavior, architecture, setup, or data formats change.
 
 extends Node2D
-## Game scene controller. Manages the active run.
+## Game scene controller. Manages the active run, combat loop, and wave progression.
+
+const TOWER_POSITION: Vector2 = Vector2(640, 360)
+
+var _tower: Node2D = null
+var _wave_number: int = 0
+var _enemies_alive: int = 0
+var _wave_spawn_queue: Array = []
+var _spawn_timer: float = 0.0
+var _wave_rest_timer: float = 0.0
+var _is_spawning: bool = false
+var _is_wave_rest: bool = false
+var _run_ended: bool = false
 
 func _ready() -> void:
 	RunState.reset()
 	EventBus.run_started.emit()
 	$HUD/EndRunButton.pressed.connect(_on_end_run_pressed)
+	_spawn_tower()
+	_start_next_wave()
 	_update_hud()
 
 func _process(delta: float) -> void:
+	if _run_ended:
+		return
 	RunState.run_time += delta
+	_process_spawning(delta)
+	if _is_wave_rest:
+		_wave_rest_timer -= delta
+		if _wave_rest_timer <= 0.0:
+			_is_wave_rest = false
+			_start_next_wave()
+	if not _is_spawning and _enemies_alive <= 0 and not _is_wave_rest and _wave_number > 0:
+		_is_wave_rest = true
+		_wave_rest_timer = Constants.WAVE_REST_TIME
+	_process_spawning(delta)
 	_update_hud()
+
+func _spawn_tower() -> void:
+	var tower_scene: PackedScene = preload("res://scenes/Tower.tscn")
+	_tower = tower_scene.instantiate()
+	add_child(_tower)
+	_tower.global_position = TOWER_POSITION
+	_tower.died.connect(_on_tower_died)
+
+func _on_tower_died() -> void:
+	_end_run()
 
 func _on_end_run_pressed() -> void:
 	_end_run()
 
 func _end_run() -> void:
+	if _run_ended:
+		return
+	_run_ended = true
 	EventBus.run_ended.emit(
 		RunState.wave_number,
 		RunState.kills,
@@ -41,6 +80,79 @@ func _end_run() -> void:
 		RunState.run_time
 	)
 	get_tree().change_scene_to_file("res://scenes/RunSummary.tscn")
+
+func _start_next_wave() -> void:
+	_wave_number += 1
+	RunState.wave_number = _wave_number
+	EventBus.wave_started.emit(_wave_number)
+	_build_spawn_queue()
+	_is_spawning = true
+	_spawn_timer = 0.0
+
+func _build_spawn_queue() -> void:
+	_wave_spawn_queue.clear()
+	var waves_data: Array = GameState.waves_data.get("waves", [])
+	var wave_def: Dictionary = _find_wave_definition(waves_data, _wave_number)
+	var groups: Array = wave_def.get("groups", [])
+	var scaling: Dictionary = GameState.waves_data.get("scaling", {})
+	var hp_mult: float = 1.0 + scaling.get("hp_multiplier_per_wave", 0.0) * (_wave_number - 1)
+	var count_mult: float = 1.0 + scaling.get("count_multiplier_per_wave", 0.0) * (_wave_number - 1)
+	for group in groups:
+		var enemy_id: String = group.get("enemy", "swarmer")
+		var count: int = int(group.get("count", 1) * count_mult)
+		var delay: float = group.get("delay", 0.5)
+		var enemy_data: Dictionary = GameState.get_enemy_by_id(enemy_id)
+		if enemy_data.is_empty():
+			continue
+		if hp_mult > 1.0:
+			enemy_data["hp"] = int(enemy_data.get("hp", 15) * hp_mult)
+		for i in count:
+			_wave_spawn_queue.append({"data": enemy_data.duplicate(), "delay": delay})
+
+func _find_wave_definition(waves_data: Array, wave: int) -> Dictionary:
+	var best: Dictionary = {}
+	for w in waves_data:
+		if w.get("wave", 0) <= wave:
+			best = w
+		else:
+			break
+	if best.is_empty() and waves_data.size() > 0:
+		best = waves_data[0]
+	return best
+
+func _process_spawning(delta: float) -> void:
+	if not _is_spawning or _wave_spawn_queue.is_empty():
+		if _is_spawning and _wave_spawn_queue.is_empty():
+			_is_spawning = false
+		return
+	_spawn_timer -= delta
+	if _spawn_timer <= 0.0:
+		var entry: Dictionary = _wave_spawn_queue.pop_front()
+		_spawn_enemy(entry["data"])
+		_spawn_timer = entry.get("delay", 0.5)
+
+func _spawn_enemy(data: Dictionary) -> void:
+	var enemy_scene: PackedScene = preload("res://scenes/Enemy.tscn")
+	var enemy: Node2D = enemy_scene.instantiate()
+	add_child(enemy)
+	enemy.global_position = _get_spawn_position()
+	enemy.setup(data, TOWER_POSITION)
+	enemy.died.connect(_on_enemy_died)
+	_enemies_alive += 1
+	EventBus.enemy_spawned.emit(data.get("id", "unknown"))
+
+func _on_enemy_died(_enemy: Node2D) -> void:
+	_enemies_alive -= 1
+
+func _get_spawn_position() -> Vector2:
+	var side: int = randi() % 4
+	var margin: float = 40.0
+	match side:
+		0: return Vector2(randf() * 1280, -margin)
+		1: return Vector2(randf() * 1280, 720 + margin)
+		2: return Vector2(-margin, randf() * 720)
+		3: return Vector2(1280 + margin, randf() * 720)
+		_: return Vector2(-margin, 360)
 
 func _update_hud() -> void:
 	var hud_panel: HBoxContainer = $HUD/HUDPanel


### PR DESCRIPTION
## Summary

Implements Issue #9 - Death and Restart. Wires the full combat loop: Tower spawns, enemies attack in waves, tower death triggers run summary.

### Changes
| File | Change |
|------|--------|
| scripts/ui/Game.gd | Full rewrite: Tower instantiation, wave-based enemy spawning from JSON, tower death detection, wave rest timers |
| scenes/Game.tscn | Removed inline Tower placeholder (now code-instantiated) |
| scripts/combat/Tower.gd | Added to tower group for Enemy targeting |

### Acceptance Criteria
- [x] Player can die (tower HP <= 0 triggers _end_run)
- [x] Run summary appears (transition to RunSummary.tscn)
- [x] Restart begins a clean new run (RunState.reset() on game start)
- [x] No old enemies/projectiles remain after restart (change_scene_to_file clears scene tree)

### Combat Loop

Tower spawns at center -> Enemies spawn at edges -> Tower auto-fires at nearest enemy -> Enemies move toward tower and attack -> Tower HP drops -> HP <= 0 -> Run Summary

Wave progression uses waves.json with HP/count scaling per wave.

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wave-based combat system with timed enemy spawning and progression
  * Tower and enemy death mechanics now affect gameplay and run state
  * Implemented run progression through multiple combat waves with rest periods between waves
  * Run completion now recorded and tracked for player progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->