### PR TITLE
fix: correct sub_resource ordering in .tscn files and background positioning

### DIFF
--- a/scenes/Enemy.tscn
+++ b/scenes/Enemy.tscn
@@ -1,6 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://bqenemy001"]
+[gd_scene load_steps=3 format=3 uid="uid://bqenemy001"]
 
 [ext_resource type="Script" path="res://scripts/combat/Enemy.gd" id="1_enemy"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_enemy"]
+resource_name = "CircleShape2D_enemy"
+radius = 10.0
 
 [node name="Enemy" type="Node2D"]
 script = ExtResource("1_enemy")
@@ -18,7 +22,3 @@ collision_mask = 1
 
 [node name="HitboxCollision" type="CollisionShape2D" parent="Hitbox"]
 shape = SubResource("CircleShape2D_enemy")
-
-[sub_resource type="CircleShape2D" id="CircleShape2D_enemy"]
-resource_name = "CircleShape2D_enemy"
-radius = 10.0

--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -6,10 +6,10 @@
 script = ExtResource("1_game")
 
 [node name="Background" type="ColorRect" parent="."]
-offset_left = -640.0
-offset_top = -360.0
-offset_right = 640.0
-offset_bottom = 360.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 1280.0
+offset_bottom = 720.0
 color = Color(0.03, 0.03, 0.06, 1)
 
 [node name="HUD" type="CanvasLayer" parent="."]

--- a/scenes/Projectile.tscn
+++ b/scenes/Projectile.tscn
@@ -1,6 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://bqprojectile001"]
+[gd_scene load_steps=3 format=3 uid="uid://bqprojectile001"]
 
 [ext_resource type="Script" path="res://scripts/combat/Projectile.gd" id="1_proj"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_proj"]
+resource_name = "CircleShape2D_proj"
+radius = 4.0
 
 [node name="Projectile" type="Node2D"]
 script = ExtResource("1_proj")
@@ -18,7 +22,3 @@ collision_mask = 2
 
 [node name="HitboxCollision" type="CollisionShape2D" parent="Hitbox"]
 shape = SubResource("CircleShape2D_proj")
-
-[sub_resource type="CircleShape2D" id="CircleShape2D_proj"]
-resource_name = "CircleShape2D_proj"
-radius = 4.0

--- a/scenes/Tower.tscn
+++ b/scenes/Tower.tscn
@@ -1,6 +1,14 @@
-[gd_scene load_steps=2 format=3 uid="uid://bqtower001"]
+[gd_scene load_steps=4 format=3 uid="uid://bqtower001"]
 
 [ext_resource type="Script" path="res://scripts/combat/Tower.gd" id="1_tower"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_range"]
+resource_name = "CircleShape2D_range"
+radius = 300.0
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_hitbox"]
+resource_name = "CircleShape2D_hitbox"
+radius = 22.0
 
 [node name="Tower" type="Node2D"]
 script = ExtResource("1_tower")
@@ -34,11 +42,3 @@ collision_mask = 4
 
 [node name="HitboxCollision" type="CollisionShape2D" parent="Hitbox"]
 shape = SubResource("CircleShape2D_hitbox")
-
-[sub_resource type="CircleShape2D" id="CircleShape2D_range"]
-resource_name = "CircleShape2D_range"
-radius = 300.0
-
-[sub_resource type="CircleShape2D" id="CircleShape2D_hitbox"]
-resource_name = "CircleShape2D_hitbox"
-radius = 22.0

--- a/scripts/ui/Game.gd
+++ b/scripts/ui/Game.gd
@@ -47,7 +47,6 @@ func _process(delta: float) -> void:
 	if not _is_spawning and _enemies_alive <= 0 and not _is_wave_rest and _wave_number > 0:
 		_is_wave_rest = true
 		_wave_rest_timer = Constants.WAVE_REST_TIME
-	_process_spawning(delta)
 	_update_hud()
 
 func _spawn_tower() -> void:


### PR DESCRIPTION
## Problem
Tower.tscn, Enemy.tscn, and Projectile.tscn had [sub_resource] blocks placed AFTER [node] blocks. Godot requires sub_resources to be declared before nodes that reference them. This caused all three scenes to fail loading, resulting in a blank game.

Also: Game.tscn Background ColorRect was positioned at (-640,-360) to (640,360) which only covers the bottom-right quarter of the viewport when root is at (0,0).

### Fixes
- Move [sub_resource] blocks before [node] blocks in Tower.tscn, Enemy.tscn, Projectile.tscn
- Fix load_steps counts
- Fix Game.tscn Background to (0,0) to (1280,720)
- Remove duplicate _process_spawning(delta) call in Game.gd